### PR TITLE
ci: Add x86 based macOS to testing matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,6 +48,9 @@ jobs:
         include:
           - python-version: pypy-3.10
             runs-on: ubuntu-latest
+          # Intel runner
+          - runs-on: macos-13
+            python-version: "3.12"          
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
* "macos-latest" now uses Apple silicon runners, so use "macos-13" to have access to an x86 based macOS runner.